### PR TITLE
More updates for better Renovate support

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,17 +1,27 @@
+# renovate: datasource=github-tags depName=npryce/adr-tools
 adr-tools 3.0.0
 awscli 2.11.0
+# renovate: datasource=github-tags depName=bridgecrewio/checkov
 checkov 2.3.3
+# renovate: datasource=github-tags depName=fluxcd/flux2
 flux2 0.41.2
 golang 1.19.5
+# renovate: datasource=github-tags depName=golangci/golangci-lint
 golangci-lint 1.50.1
+# renovate: datasource=github-tags depName=hadolint/hadolint
 hadolint 2.12.0
 helm 3.11.2
+# renovate: datasource=github-tags depName=kubernetes/kubernetes
 kubectl 1.26.3
 make 4.4
+# renovate: datasource=github-tags depName=pre-commit/pre-commit
 pre-commit 3.0.1
 python 3.11.1
 sops 3.7.3
 terraform 1.4.4
+# renovate: datasource=github-tags depName=terraform-docs/terraform-docs
 terraform-docs 0.16.0
+# renovate: datasource=github-tags depName=terraform-linters/tflint
 tflint 0.44.1
+# renovate: datasource=github-tags depName=aquasecurity/tfsec
 tfsec 1.28.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,9 @@ RUN dnf install -y --refresh \
 
 # Install asdf. Get versions from https://github.com/asdf-vm/asdf/releases
 # hadolint ignore=SC2016
-# renovate: datasource=github-tags depName=asdf-vm/asdf versioning=semver-coerced
-ENV ASDF_VERSION=v0.11.1
-RUN git clone https://github.com/asdf-vm/asdf.git --branch ${ASDF_VERSION} --depth 1 "${HOME}/.asdf" \
+# renovate: datasource=github-tags depName=asdf-vm/asdf
+ENV ASDF_VERSION=0.11.1
+RUN git clone https://github.com/asdf-vm/asdf.git --branch v${ASDF_VERSION} --depth 1 "${HOME}/.asdf" \
   && echo -e '\nsource $HOME/.asdf/asdf.sh' >> "${HOME}/.bashrc" \
   && echo -e '\nsource $HOME/.asdf/asdf.sh' >> "${HOME}/.profile" \
   && source "${HOME}/.asdf/asdf.sh"

--- a/renovate.json5
+++ b/renovate.json5
@@ -30,13 +30,23 @@
     enabled: true
   },
   "regexManagers": [
-    // Custom regex manager that follows the pattern documented here: https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
+    // Custom regex manager for the Dockerfile that follows the pattern documented here: https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
     {
       "fileMatch": ["^Dockerfile$"],
       "matchStrings": [
         "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sENV .*?_VERSION=(?<currentValue>.*)\\s"
       ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
+      "extractVersionTemplate": "^v?(?<version>.*)$"
+    },
+    // Custom regex manager for the .tool-versions file that follows the pattern documented here: https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
+    {
+      "fileMatch": ["^.tool-versions$"],
+      "matchStrings": [
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*? (?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
+      "extractVersionTemplate": "^v?(?<version>.*)$"
     }
   ]
 }


### PR DESCRIPTION
Tested [here](https://github.com/RothAndrew/not-a-build-harness/pull/2)

Until https://github.com/renovatebot/renovate/pull/21942 is merged we will use a RegexManager for the ASDF plugins that aren't supported by Renovate yet.