### PR TITLE
Change Renovate schedule to "on demand"

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,8 +14,6 @@
     "replacements:all",
     // Apply crowd-sourced workarounds for known problems with packages. See https://docs.renovatebot.com/presets-workarounds/#workaroundsall
     "workarounds:all",
-    // Only run outside of office hours. See https://docs.renovatebot.com/presets-schedule/#schedulenonofficehours
-    "schedule:nonOfficeHours"
   ],
   // Labels to set in Pull Request. See https://docs.renovatebot.com/configuration-options/#labels
   labels: [


### PR DESCRIPTION
It is difficult to diagnose issues since Renovate is currently configured to only run outside of work hours.

The intention for the "outside of work hours" schedule is to make it less noisy, but since it is already configured to do everything in one PR it is already fairly "quiet"