### PR TITLE
Stop caching docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,3 +38,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          no-cache: true

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -29,3 +29,4 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          no-cache: true


### PR DESCRIPTION
Because docker was caching layers, the `dnf install` run step wasn't being run. This resulted in old versions of tools being installed when we actually want the latest version. Example: Git latest version is ~2.40 and the version installed was ~2.31